### PR TITLE
Makefile: default to "gcc", and just make the binary

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -21,7 +21,7 @@ jobs:
         timeout-minutes: 2
         run: |
           make clean
-          NO_ASAN=1 make CC=gcc -B ansi2html-static
+          NO_ASAN=1 make -B ansi2html-static
           mv ansi2html-static ansi2html
       - name: test minimal conversion
         timeout-minutes: 1

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -22,12 +22,12 @@ jobs:
       - name: attempt compilation w/o asan
         timeout-minutes: 2
         run: |
-          NO_ASAN=1 make CC=gcc -B ansi2html
+          NO_ASAN=1 make -B ansi2html
       - name: attempt compilation with asan
         timeout-minutes: 2
         run: |
           make clean
-          make CC=gcc -B ansi2html
+          make -B ansi2html
       - name: run tests
         timeout-minutes: 1
         run: |
@@ -36,7 +36,7 @@ jobs:
         timeout-minutes: 2
         run: |
           make clean
-          NO_ASAN=1 make CC=gcc -B ansi2html-static
+          NO_ASAN=1 make -B ansi2html-static
       - name: test minimal conversion
         timeout-minutes: 1
         run: |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL = /bin/bash
 .SHELLFLAGS = -e -c
 
-CC = gcc-14
+CC = gcc
 
 C_FLAGS = -O2 -D_GNU_SOURCE -ggdb3 -march=native -Wall -Wextra -Werror -Wformat-security -Wshadow -Wredundant-decls
 ifeq (,$(findstring ++,$(CC)))
@@ -54,15 +54,17 @@ src/ansi2html.c src/main.c src/structs/ansi_color_palette.c src/structs/ansi_col
 H_FILES = \
 src/ansi2html.h src/structs/ansi_color.h src/structs/ansi_color_palette.h src/structs/ansi_color_type.h src/structs/ansi_fg_or_bg.h src/structs/ansi_rgb.h src/structs/ansi_style.h src/structs/ansi_style_properties.h
 
-.PHONY: all
-all: format tags ansi2html
-
+# This comes first so one can just "make" and just make the executable.
+# I'll just go do "make all" instead.
 ansi2html: Makefile $(C_FILES) $(H_FILES)
 	@rm -f $@
 	@start=$$(perl -MTime::HiRes=gettimeofday -E'say scalar gettimeofday')
 	$(CC) $(C_FLAGS) $(L_FLAGS) $(ADD_L_FLAGS) -o $@ $(C_FILES)
 	@end=$$(perl -MTime::HiRes=gettimeofday -E'say scalar gettimeofday')
 	@perl -E'say sprintf "Build  time: %.4f seconds", $$ARGV[1] - $$ARGV[0]' "$$start" "$$end"
+
+.PHONY: all
+all: format tags ansi2html
 
 .PHONY: format
 format: Makefile $(C_FILES) $(H_FILES)

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ You can use the `--palette NAME --rgb-for 0-16` option to show the RGB color for
 You can likely get away with something like this, until I get automations working:
 
 ```bash
-NO_ASAN=1 make CC=gcc ansi2html
-NO_ASAN=1 make CC=clang ansi2html
+env NO_ASAN=1 make ansi2html
+env NO_ASAN=1 make CC=clang ansi2html
 ```
 
 ## How to compile (developer)
 
-Assuming you've `gcc-14` installed, just run `make`. It'll:
+Run `make CC=gcc-14 all`. It'll:
 
 - format the code (you'll need `clang-format` installed)
 - create the tags file (you'll need `ctags` installed)
-- compile the program with `gcc-14`
+- compile the program with `gcc-14` and with ASAN enabled
 
 Else, use the `CC` variable to specify the compiler you want to use, the `NO_ASAN=1` variable to disable Address Sanitizer, and the `ansi2html` target if you just want the executable.
 

--- a/src/main.c
+++ b/src/main.c
@@ -7,7 +7,7 @@
     "Usage: %s [options]\n"                                                    \
     "Options:\n"                                                               \
     "  --help                   Show this help.\n"                             \
-    "  --palette, -p <name>     Use the named palette.\n"                      \
+    "  --palette, -p <name>     Use the named palette. Default is vga.\n"      \
     "  --rgb-for <0-16>         Show the #RRGGBB for the given palette.\n"     \
     "                           Only usable after a valid --palette.\n"        \
     "  --bold-is-bright, -b     A bold color is a bright color.\n"             \
@@ -48,8 +48,8 @@ int main(int argc, char *argv[])
 
     // We start with a "reset" style:
     struct ansi_style style = {0};
-    // Need to provide a known palette.
-    struct ansi_color_palette *palette = NULL;
+    // Need to provide a known palette. This is the default:
+    struct ansi_color_palette *palette = PALETTE_VGA;
 
     // Want this wrapped in a "pre" block?
     bool wrap_in_pre = false;


### PR DESCRIPTION
I'll take care of the formatting, gcc-14 etc. myself with aliases and the like.

Also update docs to use `env` so the command can likely run on other shells which apparently can't take VAR=VALUE before the commands.