### PR TITLE
add some support for classes rather than in-line styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ If `--pre` is enabled, it will add the default foreground and background color t
 
 You can use the `--palette NAME --rgb-for 0-16` option to show the RGB color for the given 0-16 color.
 
+By default, the program uses in-line styles for the colors. If you want to use CSS classes instead, use the `--use-classes` option. You can output the CSS contents that should go in the `style` tag with the `--show-style-tag` option.
+
+Example:
+
+```bash
+(
+    printf '<!DOCTYPE html><head><title>...</title>\n';
+    printf '<style>\n;
+    ansi2html --palette vga --show-style-tag;
+    printf '\n/* Additional styles... */\n';
+    printf '</style>\n';
+    printf '</head><body><!-- additional markup -->\n';
+    ansi2html --palette vga --use-classes --pre < input.txt
+    printf '<!-- more markup -->\n';
+    printf '</body></html>\n';
+) > output.html
+```
+
 ## How to compile (user)
 
 You can likely get away with something like this, until I get automations working:

--- a/src/ansi2html.h
+++ b/src/ansi2html.h
@@ -11,10 +11,15 @@ extern void show_ansi_style(
     struct ansi_style *s, const char *file, int line, const char *funcname
 );
 
-extern void
-ansi_style_span_style(struct ansi_style *s, struct ansi_color_palette *palette);
+extern void ansi_span_start(
+    struct ansi_style *s, struct ansi_color_palette *palette, bool use_classes
+);
 
 extern void
 reset_ansi_props(struct ansi_style *s, struct ansi_color_palette *palette);
 
 extern void showcase_palette(struct ansi_color_palette *palette);
+
+extern void ansi256_to_rgb(
+    int color, struct ansi_color_palette *palette, struct ansi_rgb *rgb
+);

--- a/src/structs/ansi_color.h
+++ b/src/structs/ansi_color.h
@@ -14,7 +14,7 @@ struct ansi_color
     struct ansi_fg_or_bg *fg_or_bg;
     // The RGB of this color:
     struct ansi_rgb rgb;
-    // Whether the color was one of the lower 16 (useful for "bold is bright")
+    // Whether the color was one of the 256 (useful for "bold is bright")
     bool is_base_color;
     // If it was a base color, which one?
     unsigned char base_color;


### PR DESCRIPTION
i.e. track/recognise that a color was one of the 16 or 256, and output the proper class name for it (fore and background); and use class names for "features" (i.e. bold, bright, etc) if enabled.

Also, provide an option to output the contents of the style tag for the chosen palette.

Also, "fix" the setting of the background/foreground to "initial", unneeded.