### PR TITLE
Mf/202407 fix bold is bright

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,7 +15,7 @@ jobs:
       - name: install prerequisites
         timeout-minutes: 10
         run: |
-          apk add --no-cache clang musl-dev binutils xz nodejs
+          apk add --no-cache clang musl-dev binutils xz nodejs mingw-w64-gcc
       - name: static compilation with clang/musl [no iTerm2 palettes]
         timeout-minutes: 2
         run: |
@@ -38,11 +38,21 @@ jobs:
           echo
           printf '\e[0;31mred\e[0;1;31mbright red\e[0m' | ./ansi2html -b -p i2_laser
           echo
+      - name: static compilation [no iTerm2 palettes] with mingw32-w64
+        timeout-minutes: 2
+        run: |
+          x86_64-w64-mingw32-cc -O2 -flto -o ansi2html-noi2.exe -static -Wl,-strip-all -Wl,-static src/ansi2html.c src/main.c src/structs/ansi_color_palette.c src/structs/ansi_color_type.c src/structs/ansi_fg_or_bg.c
+      - name: static compilation [with iTerm2 palettes] with mingw32-w64
+        timeout-minutes: 2
+        run: |
+          x86_64-w64-mingw32-cc -O2 -DITERM2_COLOR_SCHEMES -flto -o ansi2html.exe -static -Wl,-strip-all -Wl,-static src/ansi2html.c src/main.c src/structs/ansi_color_palette.c src/structs/ansi_color_type.c src/structs/ansi_fg_or_bg.c src/iterm2_color_schemes/ansi_color_palette.c
       - name: compress binaries
         timeout-minutes: 1
         run: |
           xz --compress --stdout ansi2html > ansi2html-Linux-x86_64-musl.xz
           xz --compress --stdout ansi2html-noi2 > ansi2html-noi2-Linux-x86_64-musl.xz
+          xz --compress --stdout ansi2html-noi2.exe > ansi2html-noi2-Windows-x86_64-mingw32.xz
+          xz --compress --stdout ansi2html.exe > ansi2html-Windows-x86_64-mingw32.xz
       - name: show sizes
         timeout-minutes: 1
         run: |
@@ -55,6 +65,22 @@ jobs:
         with:
           name: ansi2html-noi2-Linux-x86_64-musl.xz
           path: ansi2html-noi2-Linux-x86_64-musl.xz
+      - uses: actions/upload-artifact@master
+        with:
+          name: ansi2html-noi2-Windows-x86_64-mingw32.xz
+          path: ansi2html-noi2-Windows-x86_64-mingw32.xz
+      - uses: actions/upload-artifact@master
+        with:
+          name: ansi2html-Windows-x86_64-mingw32.xz
+          path: ansi2html-Windows-x86_64-mingw32.xz
+      - uses: actions/upload-artifact@master
+        with:
+          name: ansi2html-noi2.exe
+          path: ansi2html-noi2.exe
+      - uses: actions/upload-artifact@master
+        with:
+          name: ansi2html.exe
+          path: ansi2html.exe
 
   release:
     needs: [build]
@@ -74,7 +100,7 @@ jobs:
     needs: [release]
     strategy:
       matrix:
-        file: ['ansi2html-Linux-x86_64-musl.xz', 'ansi2html-noi2-Linux-x86_64-musl.xz']
+        file: ['ansi2html-Linux-x86_64-musl.xz', 'ansi2html-noi2-Linux-x86_64-musl.xz', 'ansi2html-noi2-Windows-x86_64-mingw32.xz', 'ansi2html-Windows-x86_64-mingw32.xz', 'ansi2html-noi2.exe', 'ansi2html.exe']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@master

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -47,7 +47,7 @@ jobs:
       - name: install prerequisites
         timeout-minutes: 10
         run: |
-          apk add --no-cache clang musl-dev binutils xz nodejs bash perl perl-utils
+          apk add --no-cache clang musl-dev binutils xz nodejs bash perl perl-utils mingw-w64-gcc
       - name: static compilation [no iTerm2 palettes] with clang/musl
         timeout-minutes: 2
         run: |
@@ -74,11 +74,21 @@ jobs:
         timeout-minutes: 1
         run: |
           prove -v tests/*.sh
+      - name: static compilation [no iTerm2 palettes] with mingw32-w64
+        timeout-minutes: 2
+        run: |
+          x86_64-w64-mingw32-cc -O2 -flto -o ansi2html-noi2.exe -static -Wl,-strip-all -Wl,-static src/ansi2html.c src/main.c src/structs/ansi_color_palette.c src/structs/ansi_color_type.c src/structs/ansi_fg_or_bg.c
+      - name: static compilation [with iTerm2 palettes] with mingw32-w64
+        timeout-minutes: 2
+        run: |
+          x86_64-w64-mingw32-cc -O2 -DITERM2_COLOR_SCHEMES -flto -o ansi2html.exe -static -Wl,-strip-all -Wl,-static src/ansi2html.c src/main.c src/structs/ansi_color_palette.c src/structs/ansi_color_type.c src/structs/ansi_fg_or_bg.c src/iterm2_color_schemes/ansi_color_palette.c
       - name: compress binaries
         timeout-minutes: 1
         run: |
           xz --compress --stdout ansi2html > ansi2html-Linux-x86_64-musl.xz
           xz --compress --stdout ansi2html-noi2 > ansi2html-noi2-Linux-x86_64-musl.xz
+          xz --compress --stdout ansi2html-noi2.exe > ansi2html-noi2-Windows-x86_64-mingw32.xz
+          xz --compress --stdout ansi2html.exe > ansi2html-Windows-x86_64-mingw32.xz
       - name: show sizes
         timeout-minutes: 1
         run: |

--- a/src/ansi2html.c
+++ b/src/ansi2html.c
@@ -942,8 +942,9 @@ static inline void styles_for_props(
     }
     if (props->bold)
     {
-        if (!s->bold_is_bright || (s->color_foreground.is_base_color &&
-                                   s->color_foreground.base_color >= 8))
+        struct ansi_color *fg =
+            props->reverse ? &s->color_background : &s->color_foreground;
+        if (!s->bold_is_bright || !fg->is_base_color || fg->base_color >= 8)
             ADD_STYLE(true, style_bold);
     }
     else if (props->faint)

--- a/src/ansi2html.c
+++ b/src/ansi2html.c
@@ -1135,7 +1135,9 @@ char *ansi_span_start(
         (void)memcpy(p, "class=\"", 7);
         p += 7;
         *p = '\0';
-        p = stpcpy(p, classes);
+        size_t len = strlen(classes);
+        (void)memcpy(p, classes, len);
+        p += len;
         *p++ = '"';
         *p = '\0';
     }
@@ -1149,7 +1151,9 @@ char *ansi_span_start(
         (void)memcpy(p, "style=\"", 7);
         p += 7;
         *p = '\0';
-        p = stpcpy(p, styles);
+        size_t len = strlen(styles);
+        (void)memcpy(p, styles, len);
+        p += len;
         *p++ = '"';
         *p = '\0';
     }

--- a/tests/bold_is_bright.sh
+++ b/tests/bold_is_bright.sh
@@ -46,4 +46,70 @@ want='<span class="fg-1">red</span><span class="fg-9">bold/bright red</span><spa
 got=$(printf '%s' "$str" | ./ansi2html -p vga -b --use-classes)
 str_eq_html "$str" "$want" "$got"
 
+# 256 colors 0-7 with "1;" with "-b" are treated as bright:
+str=$'\e[0;38;5;1mred\e[1mbright\e[0m'
+want='<span style="color:#AA0000;">red</span><span style="color:#FF5555;">bright</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b)
+str_eq_html "$str" "$want" "$got"
+
+# With classes:
+want='<span class="fg-1">red</span><span class="fg-9">bright</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b --use-classes)
+str_eq_html "$str" "$want" "$got"
+
+# 256 colors 8-15 with "1;" with "-b" are instead _bold_:
+str=$'\e[0;38;5;9mred\e[1mbold\e[0m'
+want='<span style="color:#FF5555;">red</span><span style="font-weight:bold;color:#FF5555;">bold</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b)
+str_eq_html "$str" "$want" "$got"
+
+# With classes:
+want='<span class="fg-9">red</span><span class="bold fg-9">bold</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b --use-classes)
+str_eq_html "$str" "$want" "$got"
+
+# Also 16+:
+str=$'\e[0;38;5;88mred\e[1mbold\e[0m'
+want='<span style="color:#870000;">red</span><span style="font-weight:bold;color:#870000;">bold</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b)
+str_eq_html "$str" "$want" "$got"
+
+# With classes:
+want='<span class="fg-88">red</span><span class="bold fg-88">bold</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b --use-classes)
+str_eq_html "$str" "$want" "$got"
+
+# But also the _default color_ gets bold with "-b":
+str=$'default\e[1mbold\e[0m'
+want='default<span style="font-weight:bold;">bold</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b)
+str_eq_html "$str" "$want" "$got"
+
+# With classes:
+want='default<span class="bold">bold</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b --use-classes)
+str_eq_html "$str" "$want" "$got"
+
+# Reverse!
+str=$'default\e[1mbold\e[7mreverse\e[0m'
+want='default<span style="font-weight:bold;">bold</span><span style="font-weight:bold;color:#000000;background-color:#AAAAAA;">reverse</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b)
+str_eq_html "$str" "$want" "$got"
+
+# With classes:
+want='default<span class="bold">bold</span><span class="bold" style="color:#000000;background-color:#AAAAAA;">reverse</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b --use-classes)
+str_eq_html "$str" "$want" "$got"
+
+# Reverse with "bold is bright"!
+str=$'\e[0;31;42mredongreen\e[1mbright\e[7mreverse\e[0m'
+want='<span style="color:#AA0000;background-color:#00AA00;">redongreen</span><span style="color:#FF5555;background-color:#00AA00;">bright</span><span style="color:#55FF55;background-color:#FF5555;">reverse</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b)
+str_eq_html "$str" "$want" "$got"
+
+# Classes "detect" that "-b" shouldn't brighten the background color:
+want='<span class="fg-1 bg-2">redongreen</span><span class="fg-9 bg-2">bright</span><span class="fg-10 bg-1">reverse</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b --use-classes)
+str_eq_html "$str" "$want" "$got"
+
 done_testing


### PR DESCRIPTION
- fix some "bold is bright" cases, and test them
- use `memcpy` instead of `stpcpy`, to make this compilable under mingw
- use mingw to cross compile exes for windows