### PR TITLE
ansi2html: "bold is bright" should NOT apply to 0-7 256

### DIFF
--- a/src/ansi2html.c
+++ b/src/ansi2html.c
@@ -500,7 +500,7 @@ void set_ansi_style_properties(
             props->bold = true;
             if (style->bold_is_bright)
             {
-                if (fg->is_base_color)
+                if (fg->is_base_color && fg->color_type == COLOR_TYPE_16)
                 {
                     if (fg->base_color < 8)
                         fg->rgb = palette->bright[fg->base_color];
@@ -562,7 +562,7 @@ void set_ansi_style_properties(
             props->faint = false;
             if (style->bold_is_bright)
             {
-                if (fg->is_base_color)
+                if (fg->is_base_color && fg->color_type == COLOR_TYPE_16)
                 {
                     if (fg->base_color < 8)
                         fg->rgb = palette->base[fg->base_color];
@@ -944,7 +944,8 @@ static inline void styles_for_props(
     {
         struct ansi_color *fg =
             props->reverse ? &s->color_background : &s->color_foreground;
-        if (!s->bold_is_bright || !fg->is_base_color || fg->base_color >= 8)
+        if (!s->bold_is_bright || !fg->is_base_color ||
+            fg->color_type != COLOR_TYPE_16)
             ADD_STYLE(true, style_bold);
     }
     else if (props->faint)
@@ -1012,7 +1013,7 @@ char *ansi_span_start(
         char this_class[8] = {'f', 'g', '-', '\0', '\0', '\0', '\0'};
         unsigned char this_color = fg->base_color;
         if (s->bold_is_bright && props->bold && fg->is_base_color &&
-            fg->base_color < 8)
+            fg->base_color < 8 && fg->color_type == COLOR_TYPE_16)
             this_color += 8;
         if (this_color < 10)
         {
@@ -1064,7 +1065,7 @@ char *ansi_span_start(
     } while (0)
         struct ansi_rgb rgb = fg->rgb;
         if (s->bold_is_bright && props->bold && fg->is_base_color &&
-            fg->base_color < 8)
+            fg->base_color < 8 && fg->color_type == COLOR_TYPE_16)
             rgb = palette->bright[fg->base_color];
         COLOR2HEX(rgb, this_style + 7);
         (void)memcpy(ps, this_style, 14);

--- a/tests/bold_is_bright.sh
+++ b/tests/bold_is_bright.sh
@@ -46,18 +46,18 @@ want='<span class="fg-1">red</span><span class="fg-9">bold/bright red</span><spa
 got=$(printf '%s' "$str" | ./ansi2html -p vga -b --use-classes)
 str_eq_html "$str" "$want" "$got"
 
-# 256 colors 0-7 with "1;" with "-b" are treated as bright:
-str=$'\e[0;38;5;1mred\e[1mbright\e[0m'
-want='<span style="color:#AA0000;">red</span><span style="color:#FF5555;">bright</span>'
+# 256 colors 0-7 with "1;" with "-b" are NOT treated as bright:
+str=$'\e[0;38;5;1mred\e[1mbold dark red\e[0m'
+want='<span style="color:#AA0000;">red</span><span style="font-weight:bold;color:#AA0000;">bold dark red</span>'
 got=$(printf '%s' "$str" | ./ansi2html -p vga -b)
 str_eq_html "$str" "$want" "$got"
 
 # With classes:
-want='<span class="fg-1">red</span><span class="fg-9">bright</span>'
+want='<span class="fg-1">red</span><span class="bold fg-1">bold dark red</span>'
 got=$(printf '%s' "$str" | ./ansi2html -p vga -b --use-classes)
 str_eq_html "$str" "$want" "$got"
 
-# 256 colors 8-15 with "1;" with "-b" are instead _bold_:
+# 256 colors 8-15 with "1;" with "-b" are also _bold_:
 str=$'\e[0;38;5;9mred\e[1mbold\e[0m'
 want='<span style="color:#FF5555;">red</span><span style="font-weight:bold;color:#FF5555;">bold</span>'
 got=$(printf '%s' "$str" | ./ansi2html -p vga -b)


### PR DESCRIPTION
As the README.md states, only the 30-37 color should be brightened via the "bold is bright" feature, and _not_ the 0-7 colors in the 256 colors mode.