### PR TITLE
repo: support new "--use-compact" output option

### DIFF
--- a/src/ansi2html.h
+++ b/src/ansi2html.h
@@ -28,7 +28,8 @@ extern void show_ansi_style(
 
 // Returns a static string. Beware.
 extern char *ansi_span_start(
-    struct ansi_style *s, struct ansi_color_palette *palette, bool use_classes
+    struct ansi_style *s, struct ansi_color_palette *palette, bool use_classes,
+    bool use_compact
 );
 
 extern void

--- a/tests/base.sh
+++ b/tests/base.sh
@@ -37,6 +37,10 @@ str=$(printf 'Hello, \e[38;2;0;0;170mBlue FG\e[%sm world!' "$(for _ in $(seq 1 1
 got=$(printf '%s' "$str" | ./ansi2html -p vga)
 str_eq_html "$str" "$want" "$got"
 
+want=$'Hello, <span style="color:#00A;">Blue FG</span> world!'
+got=$(printf '%s' "$str" | ./ansi2html -p vga --use-compact)
+str_eq_html "$str" "$want" "$got"
+
 # This errors with "SGR sequence too long":
 str=$(printf '\e[%sm' "$(for _ in $(seq 1 128); do printf '0;'; done)")
 want='ERROR: SGR sequence too long, at 258 characters read / 256 in SGR sequence which begun at 2 characters read.'

--- a/tests/blue.sh
+++ b/tests/blue.sh
@@ -9,4 +9,8 @@ want=$'<span style="color:#0000AA;">Blue FG</span><span style="background-color:
 got=$(printf '%s' "$str" | ./ansi2html -p vga)
 str_eq_html "$str" "$want" "$got"
 
+want=$'<span style="color:#00A;">Blue FG</span><span style="background-color:#00A;">Blue BG</span><span style="color:#C097BC;background-color:#00A;">Nice FG/BG</span><span style="color:#00A;background-color:#C097BC;">reversed</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga --use-compact)
+str_eq_html "$str" "$want" "$got"
+
 done_testing

--- a/tests/reverse.sh
+++ b/tests/reverse.sh
@@ -14,6 +14,11 @@ got=$(printf '%s' "$str" | ./ansi2html -p vga --use-classes)
 str_eq_html "$str" "$want" "$got"
 
 str=$'\e[0;31mred\e[42mon green\e[7mreverse\e[0m'
+want='<span style="color:#A00;">red</span><span style="color:#A00;background-color:#0A0;">on green</span><span style="color:#0A0;background-color:#A00;">reverse</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga --use-compact)
+str_eq_html "$str" "$want" "$got"
+
+str=$'\e[0;31mred\e[42mon green\e[7mreverse\e[0m'
 want='<span style="color:#AA0000;">red</span><span style="color:#AA0000;background-color:#00AA00;">on green</span><span style="color:#00AA00;background-color:#AA0000;">reverse</span>'
 got=$(printf '%s' "$str" | ./ansi2html -p vga)
 str_eq_html "$str" "$want" "$got"
@@ -35,6 +40,10 @@ want='<span style="color:#FF5555;">red</span><span style="color:#FF5555;backgrou
 got=$(printf '%s' "$str" | ./ansi2html -p vga -b)
 str_eq_html "$str" "$want" "$got"
 
+want='<span style="color:#F55;">red</span><span style="color:#F55;background-color:#0A0;">on green</span><span style="color:#5F5;background-color:#F55;">reverse</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga -b --use-compact)
+str_eq_html "$str" "$want" "$got"
+
 want='<span class="fg-9">red</span><span class="fg-9 bg-2">on green</span><span class="fg-10 bg-1">reverse</span>'
 got=$(printf '%s' "$str" | ./ansi2html -p vga -b --use-classes)
 str_eq_html "$str" "$want" "$got"
@@ -43,6 +52,10 @@ str_eq_html "$str" "$want" "$got"
 str=$'\e[0;40;37mgreyonblack\e[7mreversed\e[0;30;47msame\e[0m'
 want='<span style="color:#AAAAAA;background-color:#000000;">greyonblack</span><span style="color:#000000;background-color:#AAAAAA;">reversed</span><span style="color:#000000;background-color:#AAAAAA;">same</span>'
 got=$(printf '%s' "$str" | ./ansi2html -p vga --rgb-for fg '#989898' --rgb-for bg '#111111')
+str_eq_html "$str" "$want" "$got"
+
+want='<span style="color:#AAA;background-color:#000;">greyonblack</span><span style="color:#000;background-color:#AAA;">reversed</span><span style="color:#000;background-color:#AAA;">same</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga --rgb-for fg '#989898' --rgb-for bg '#111111' --use-compact)
 str_eq_html "$str" "$want" "$got"
 
 # But when bold + "bold is bright" is in the mix... oh boy


### PR DESCRIPTION
... for outputting, where possible, "compact" hex codes, i.e. "#0af" in place of "#00aaff" but only where all three red, green and blue are representable using just one "doubled" hex digit (which it turns out, "just" means checking whether the modulus with 17 is 0).

This also takes effect for the "--show-style-tag" option, provided the "--use-compact" option is enabled before using it.

Somewhat oddly, it would seem that the minimal refactoring/re-macroing performed in COLOR2HEX and the way the memcpy is done towards the "this_style" buffer gains a noticeable speed-up despite the new option NOT being used. That is, using the new option results in slower runtime, but with this new code not using it is faster than what was on master previously.

Given:

    $ wc -c foo100.txt
    517379100 foo100.txt
    $ ./ansi2html-clang < foo100.txt | wc -c
    1133143500
    $ ./ansi2html-clang-master < foo100.txt | wc -c
    1133143500
    $ ./ansi2html-clang < foo100.txt | sha1sum -
    26db1f7bdf6b04e59683b7f099fb46245e898918  -
    $ ./ansi2html-clang-master < foo100.txt | sha1sum -
    26db1f7bdf6b04e59683b7f099fb46245e898918  -

... the one built "at" this commit seemingly performs much better when the option is NOT set:

    $ ./ansi2html-clang-master < foo100.txt | pv -N out >/dev/null
          out: 1.06GiB 0:00:01 [ 701MiB/s] [           <=>     ]
    $ ./ansi2html-clang < foo100.txt | pv -N out >/dev/null
          out: 1.06GiB 0:00:01 [ 865MiB/s] [           <=>     ]

... but a bit worse when it's asked to use the new compact representation:

    $ ./ansi2html-clang --use-compact < foo100.txt | pv -N out >/dev/null
          out: 1.04GiB 0:00:01 [ 760MiB/s] [           <=>     ]

i.e.:

    $ hyperfine './ansi2html-clang-master < foo100.txt' './ansi2html-clang < foo100.txt' './ansi2html-clang --use-compact < foo100.txt'
    Benchmark 1: ./ansi2html-clang-master < foo100.txt
      Time (mean ± σ):      1.162 s ±  0.018 s    [User: 1.115 s, System: 0.044 s]
      Range (min … max):    1.146 s …  1.196 s    10 runs
    Benchmark 2: ./ansi2html-clang < foo100.txt
      Time (mean ± σ):      1.023 s ±  0.012 s    [User: 0.976 s, System: 0.044 s]
      Range (min … max):    1.002 s …  1.044 s    10 runs
    Benchmark 3: ./ansi2html-clang --use-compact < foo100.txt
      Time (mean ± σ):      1.037 s ±  0.011 s    [User: 0.986 s, System: 0.048 s]
      Range (min … max):    1.024 s …  1.053 s    10 runs
    Summary
      './ansi2html-clang < foo100.txt' ran
        1.01 ± 0.02 times faster than './ansi2html-clang --use-compact < foo100.txt'
        1.14 ± 0.02 times faster than './ansi2html-clang-master < foo100.txt'

Not too shabby.