### PR TITLE
Mf/202501 speedup

### DIFF
--- a/src/ansi2html.c
+++ b/src/ansi2html.c
@@ -997,28 +997,31 @@ static inline void styles_for_props(
             slen += spec.style_len;                                            \
         }                                                                      \
     }
-    if (props->bold)
+    if (props->any)
     {
-        struct ansi_color *fg =
-            props->reverse ? &s->color_background : &s->color_foreground;
-        if (!s->bold_is_bright || !fg->is_base_color ||
-            fg->color_type != COLOR_TYPE_16)
-            ADD_STYLE(true, style_bold);
+        if (props->bold)
+        {
+            struct ansi_color *fg =
+                props->reverse ? &s->color_background : &s->color_foreground;
+            if (!s->bold_is_bright || !fg->is_base_color ||
+                fg->color_type != COLOR_TYPE_16)
+                ADD_STYLE(true, style_bold);
+        }
+        else if (props->faint)
+        {
+            ADD_STYLE(true, style_faint);
+        }
+        ADD_STYLE(props->italic, style_italic);
+        ADD_STYLE(props->double_underline, style_double_underline);
+        ADD_STYLE(props->underline, style_underline);
+        ADD_STYLE(props->slow_blink, style_slow_blink);
+        ADD_STYLE(props->fast_blink, style_fast_blink);
+        ADD_STYLE(props->crossout, style_crossout);
+        ADD_STYLE(props->fraktur, style_fraktur);
+        ADD_STYLE(props->frame, style_frame);
+        ADD_STYLE(props->circle, style_circle);
+        ADD_STYLE(props->overline, style_overline);
     }
-    else if (props->faint)
-    {
-        ADD_STYLE(true, style_faint);
-    }
-    ADD_STYLE(props->italic, style_italic);
-    ADD_STYLE(props->double_underline, style_double_underline);
-    ADD_STYLE(props->underline, style_underline);
-    ADD_STYLE(props->slow_blink, style_slow_blink);
-    ADD_STYLE(props->fast_blink, style_fast_blink);
-    ADD_STYLE(props->crossout, style_crossout);
-    ADD_STYLE(props->fraktur, style_fraktur);
-    ADD_STYLE(props->frame, style_frame);
-    ADD_STYLE(props->circle, style_circle);
-    ADD_STYLE(props->overline, style_overline);
     *style_len = slen;
     *class_len = clen;
 #undef ADD_STYLE

--- a/src/ansi2html.c
+++ b/src/ansi2html.c
@@ -1053,8 +1053,8 @@ char *ansi_span_start(
     styles_for_props(
         s, props, palette, styles, &style_len, classes, &class_len, use_classes
     );
-    char *pc = classes + class_len;
-    char *ps = styles + style_len;
+    register char *pc = classes + class_len;
+    register char *ps = styles + style_len;
     // RGB hex for "default foreground" color in the palette for foreground
     // should result in nothing at all. Also, if the current foreground color
     // Just So Happens to have the same RGB as the default foreground color.
@@ -1116,7 +1116,7 @@ char *ansi_span_start(
 #define COLOR2HEX(color, offset)                                               \
     do                                                                         \
     {                                                                          \
-        char *pstart = this_style + offset;                                    \
+        register char *pstart = this_style + offset;                           \
         if (use_compact && ((color).red % 17) == 0 &&                          \
             ((color).green % 17) == 0 && ((color).blue % 17) == 0)             \
         {                                                                      \
@@ -1198,7 +1198,7 @@ char *ansi_span_start(
     (void)ps;
     (void)pc;
     static char span_start[1024] = {0};
-    char *p = span_start;
+    register char *p = span_start;
     (void)memcpy(p, "<span ", 6);
     p += 6;
     *p = '\0';

--- a/src/main.c
+++ b/src/main.c
@@ -627,7 +627,7 @@ int main(int argc, char *argv[])
     // Read STDIN, and convert ANSI to HTML:
     do
     {
-        size_t buffer_len = FREAD(buffer, 1, sizeof(buffer), stdin);
+        register size_t buffer_len = FREAD(buffer, 1, sizeof(buffer), stdin);
         if (buffer_len == 0)
             break;
         if (buffer_len > sizeof(buffer))
@@ -636,11 +636,11 @@ int main(int argc, char *argv[])
                 "bytes.\n",
                 buffer_len, sizeof(buffer)
             );
-        int buffer_idx = 0;
+        register int buffer_idx = 0;
         while (buffer_idx < (int)buffer_len)
         {
             read++;
-            unsigned char c = buffer[buffer_idx++];
+            register unsigned char c = buffer[buffer_idx++];
             switch (state)
             {
             default:

--- a/src/structs/ansi_style_properties.h
+++ b/src/structs/ansi_style_properties.h
@@ -5,19 +5,26 @@
 
 struct ansi_style_properties
 {
-    bool bold : 1;
-    bool faint : 1;
-    bool italic : 1;
-    bool underline : 1;
-    bool slow_blink : 1;
-    bool fast_blink : 1;
-    bool reverse : 1;
-    bool crossout : 1;
-    bool fraktur : 1;
-    bool double_underline : 1;
-    bool frame : 1;
-    bool circle : 1;
-    bool overline : 1;
+    union
+    {
+        struct
+        {
+            bool bold : 1;
+            bool faint : 1;
+            bool italic : 1;
+            bool underline : 1;
+            bool slow_blink : 1;
+            bool fast_blink : 1;
+            bool reverse : 1;
+            bool crossout : 1;
+            bool fraktur : 1;
+            bool double_underline : 1;
+            bool frame : 1;
+            bool circle : 1;
+            bool overline : 1;
+        };
+        unsigned short any;
+    };
 };
 
 #endif // ANSI_STYLE_PROPERTIES_H


### PR DESCRIPTION
A couple reasonable things to speed things up a fair bit.

Given the usual test file:

```console
$ wc -c foo100.txt ; sak stripansi < foo100.txt | wc -c ; ./ansi2html < foo100.txt | wc -c ; ./ansi2html --use-classes < foo100.txt | wc -c ;
517379100 foo100.txt
167182500
1133143500
860183700
```

... there's a decent speed-up between master and this branch:

```console
$ hyperfine --time-unit millisecond --warmup 5 './ansi2html-master < foo100.txt' './ansi2html-branch < foo100.txt'
Benchmark 1: ./ansi2html-master < foo100.txt
  Time (mean ± σ):     1031.2 ms ±  16.3 ms    [User: 985.8 ms, System: 41.9 ms]
  Range (min … max):   1015.2 ms … 1063.2 ms    10 runs

Benchmark 2: ./ansi2html-branch < foo100.txt
  Time (mean ± σ):     982.6 ms ±  10.1 ms    [User: 943.6 ms, System: 34.9 ms]
  Range (min … max):   971.5 ms … 1002.8 ms    10 runs

Summary
  './ansi2html-branch < foo100.txt' ran
    1.05 ± 0.02 times faster than './ansi2html-master < foo100.txt'
```

... which can also be seen via pv's MB/s:

```console
$ ./ansi2html-master < foo100.txt | pv >/dev/null
1.06GiB 0:00:01 [ 773MiB/s] [           <=>   ]
$ ./ansi2html-branch < foo100.txt | pv >/dev/null
1.06GiB 0:00:01 [ 822MiB/s] [           <=>   ]
```