### PR TITLE
repo: opt-in/default x86_64 AVX2/SSE2 if available

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,6 +20,10 @@ jobs:
         timeout-minutes: 2
         run: |
           clang -O2 -o ansi2html-noi2 -flto -static -Wl,-strip-all -Wl,-static src/ansi2html.c src/main.c src/structs/ansi_color_palette.c src/structs/ansi_color_type.c src/structs/ansi_fg_or_bg.c src/iterm2_color_schemes/ansi_color_palette.c
+      - name: show help page
+        timeout-minutes: 1
+        run: |
+          ./ansi2html-noi2 --help
       - name: test minimal conversion [no iTerm2 palettes]
         timeout-minutes: 1
         run: |
@@ -31,6 +35,10 @@ jobs:
         timeout-minutes: 2
         run: |
           clang -O2 -DITERM2_COLOR_SCHEMES -flto -o ansi2html -static -Wl,-strip-all -Wl,-static src/ansi2html.c src/main.c src/structs/ansi_color_palette.c src/structs/ansi_color_type.c src/structs/ansi_fg_or_bg.c src/iterm2_color_schemes/ansi_color_palette.c
+      - name: show help page
+        timeout-minutes: 1
+        run: |
+          ./ansi2html --help
       - name: test minimal conversion [with iTerm2 palettes]
         timeout-minutes: 1
         run: |
@@ -93,6 +101,10 @@ jobs:
         timeout-minutes: 2
         run: |
           clang -O2 -target ${{matrix.arch}}-apple-darwin -o ansi2html-noi2 -flto src/ansi2html.c src/main.c src/structs/ansi_color_palette.c src/structs/ansi_color_type.c src/structs/ansi_fg_or_bg.c
+      - name: show help page
+        timeout-minutes: 1
+        run: |
+          ./ansi2html-noi2 --help
       - name: "Test minimal conversion for ${{matrix.arch}} [no iTerm2 palettes]"
         timeout-minutes: 1
         run: |
@@ -109,6 +121,10 @@ jobs:
         timeout-minutes: 2
         run: |
           clang -O2 -DITERM2_COLOR_SCHEMES -target ${{matrix.arch}}-apple-darwin -o ansi2html -flto src/ansi2html.c src/main.c src/structs/ansi_color_palette.c src/structs/ansi_color_type.c src/structs/ansi_fg_or_bg.c src/iterm2_color_schemes/ansi_color_palette.c
+      - name: show help page
+        timeout-minutes: 1
+        run: |
+          ./ansi2html --help
       - name: "Test minimal conversion for ${{matrix.arch}} [with iTerm2 palettes]"
         timeout-minutes: 1
         run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -23,11 +23,19 @@ jobs:
         timeout-minutes: 2
         run: |
           NO_ASAN=1 make -B ansi2html
+      - name: show help page
+        timeout-minutes: 1
+        run: |
+          ./ansi2html --help
       - name: attempt compilation with asan
         timeout-minutes: 2
         run: |
           make clean
           make -B ansi2html
+      - name: show help page
+        timeout-minutes: 1
+        run: |
+          ./ansi2html --help
       - name: test minimal conversion
         timeout-minutes: 1
         run: |
@@ -52,10 +60,18 @@ jobs:
         timeout-minutes: 2
         run: |
           clang -O2 -o ansi2html-noi2 -flto -static -Wl,-strip-all -Wl,-static src/ansi2html.c src/main.c src/structs/ansi_color_palette.c src/structs/ansi_color_type.c src/structs/ansi_fg_or_bg.c
+      - name: show help page
+        timeout-minutes: 1
+        run: |
+          ./ansi2html-noi2 --help
       - name: static compilation [with iTerm2 palettes] with clang/musl
         timeout-minutes: 2
         run: |
           clang -O2 -DITERM2_COLOR_SCHEMES -o ansi2html -flto -static -Wl,-strip-all -Wl,-static src/ansi2html.c src/main.c src/structs/ansi_color_palette.c src/structs/ansi_color_type.c src/structs/ansi_fg_or_bg.c src/iterm2_color_schemes/ansi_color_palette.c
+      - name: show help page
+        timeout-minutes: 1
+        run: |
+          ./ansi2html --help
       - name: test minimal conversion [no iTerm2 palettes]
         timeout-minutes: 1
         run: |
@@ -111,6 +127,10 @@ jobs:
           echo
           printf '\e[0;31mred\e[0;1;31mbright red\e[0m' | ./ansi2html-noi2 -b -p vga
           echo
+      - name: show help page
+        timeout-minutes: 1
+        run: |
+          ./ansi2html-noi2 --help
       - name: "Compress for ${{matrix.arch}} [no iTerm2 palettes]"
         timeout-minutes: 1
         run: |
@@ -127,6 +147,10 @@ jobs:
           echo
           printf '\e[0;31mred\e[0;1;31mbright red\e[0m' | ./ansi2html -b -p vga
           echo
+      - name: show help page
+        timeout-minutes: 1
+        run: |
+          ./ansi2html --help
       - name: run tests
         timeout-minutes: 1
         run: |

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ env NO_ASAN=1 make ansi2html
 env NO_ASAN=1 make CC=clang ansi2html
 ```
 
+For the `-S` option (strip ANSI codes), on x86_64 an AVX2 or SSE2 version is available when compiled with `-march=native`.
+To pick a specific implementation (which can only be compiled if possible), pass on `-DWANT_SSE2` or `-DWANT_AVX2` in `CC=` or `DEFINES`.
+Alternatively, use `-DWANT_DEFAULT` to use the default implementation (i.e. without any forced intrinsics).
+
 ## How to compile (developer)
 
 Run `make CC=gcc-14 all`. It'll:

--- a/tests/align-256-ansi2html-digits.sh
+++ b/tests/align-256-ansi2html-digits.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+. "$(dirname "$0")/".functions.sh
+
+for seqi in $(seq 0 254); do
+
+    str="A$(for i in $(seq 1 "$seqi"); do printf '\e[38;5;%dm%d' "$i" "$i"; done)$(printf '\e[0m')B"
+    want="A$(for i in $(seq 1 "$seqi"); do printf '<span class="fg-%d">%d</span>' "$i" "$i"; done)B"
+    got=$(printf '%s' "$str" | ./ansi2html --rgb-for fg F011F0 -p vga --use-classes)
+    str_eq_html "$str" "$want" "$got"
+
+done
+
+done_testing

--- a/tests/align-256-ansi2html.sh
+++ b/tests/align-256-ansi2html.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+. "$(dirname "$0")/".functions.sh
+
+for seqi in $(seq 0 254); do
+
+    str="A$(for i in $(seq 1 "$seqi"); do printf '\e[38;5;%dmX' "$i"; done)$(printf '\e[0m')B"
+    want="A$(for i in $(seq 1 "$seqi"); do printf '<span class="fg-%d">X</span>' "$i"; done)B"
+    got=$(printf '%s' "$str" | ./ansi2html --rgb-for fg F011F0 -p vga --use-classes)
+    str_eq_html "$str" "$want" "$got"
+
+done
+
+done_testing

--- a/tests/align-256-strip-digits.sh
+++ b/tests/align-256-strip-digits.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+. "$(dirname "$0")/".functions.sh
+
+for seqi in $(seq 0 254); do
+
+    str="A$(for i in $(seq 1 "$seqi"); do printf '\e[38;5;%dm%d' "$i" "$i"; done)$(printf '\e[0m')B"
+    want="A$(for i in $(seq 1 "$seqi"); do printf '%d' "$i"; done)B"
+    got=$(printf '%s' "$str" | ./ansi2html -S)
+    str_eq_html "$str" "$want" "$got"
+
+done
+
+done_testing

--- a/tests/align-256-strip.sh
+++ b/tests/align-256-strip.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+. "$(dirname "$0")/".functions.sh
+
+for seqi in $(seq 0 254); do
+
+    str="A$(for i in $(seq 1 "$seqi"); do printf '\e[38;5;%dmX' "$i"; done)$(printf '\e[0m')B"
+    want="A$(for i in $(seq 1 "$seqi"); do printf 'X'; done)B"
+    got=$(printf '%s' "$str" | ./ansi2html -S)
+    str_eq_html "$str" "$want" "$got"
+
+done
+
+done_testing

--- a/tests/align-rgb-ansi2html-digits.sh
+++ b/tests/align-rgb-ansi2html-digits.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+. "$(dirname "$0")/".functions.sh
+
+for seqi in $(seq 0 254); do
+
+    str="A$(for i in $(seq 1 "$seqi"); do printf '\e[38;2;%d;%d;%dm%d' "$i" "$i" "$i" "$i"; done)$(printf '\e[0m')B"
+    want="A$(for i in $(seq 1 "$seqi"); do printf '<span style="color:#%02X%02X%02X;">%d</span>' "$i" "$i" "$i" "$i"; done)B"
+    got=$(printf '%s' "$str" | ./ansi2html --rgb-for fg F011F0 -p vga --use-classes)
+    str_eq_html "$str" "$want" "$got"
+
+done
+
+done_testing

--- a/tests/align-rgb-ansi2html.sh
+++ b/tests/align-rgb-ansi2html.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+. "$(dirname "$0")/".functions.sh
+
+for seqi in $(seq 0 254); do
+
+    str="A$(for i in $(seq 1 "$seqi"); do printf '\e[38;2;%d;%d;%dmX' "$i" "$i" "$i"; done)$(printf '\e[0m')B"
+    want="A$(for i in $(seq 1 "$seqi"); do printf '<span style="color:#%02X%02X%02X;">X</span>' "$i" "$i" "$i"; done)B"
+    got=$(printf '%s' "$str" | ./ansi2html --rgb-for fg F011F0 -p vga --use-classes)
+    str_eq_html "$str" "$want" "$got"
+
+done
+
+done_testing

--- a/tests/align-rgb-strip-digits.sh
+++ b/tests/align-rgb-strip-digits.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+. "$(dirname "$0")/".functions.sh
+
+for seqi in $(seq 0 254); do
+
+    str="A$(for i in $(seq 1 "$seqi"); do printf '\e[38;2;%d;%d;%dm%d' "$i" "$i" "$i" "$i"; done)$(printf '\e[0m')B"
+    want="A$(for i in $(seq 1 "$seqi"); do printf '%d' "$i"; done)B"
+    got=$(printf '%s' "$str" | ./ansi2html -S)
+    str_eq_html "$str" "$want" "$got"
+
+done
+
+done_testing

--- a/tests/align-rgb-strip.sh
+++ b/tests/align-rgb-strip.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+. "$(dirname "$0")/".functions.sh
+
+for seqi in $(seq 0 254); do
+
+    str="A$(for i in $(seq 1 "$seqi"); do printf '\e[38;2;%d;%d;%dmX' "$i" "$i" "$i"; done)$(printf '\e[0m')B"
+    want="A$(for i in $(seq 1 "$seqi"); do printf 'X'; done)B"
+    got=$(printf '%s' "$str" | ./ansi2html -S)
+    str_eq_html "$str" "$want" "$got"
+
+done
+
+done_testing

--- a/tests/align.sh
+++ b/tests/align.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+set -e
+
+. "$(dirname "$0")/".functions.sh
+
+# Various tests for -S which strips ANSI sequences.
+# The input strings are in various "states" of 16-byte and 32-byte alignment,
+# to ensure the AVX2 and SSE2 code paths are tested properly.
+
+S08='1_3_5_7X'
+S16='123456789_12345A'
+S32='123456789_123456789_1234567890A'
+
+# No ANSI sequences, less than 16 bytes.
+#     1234567890123
+str=$'Hello, world!'
+want=$'Hello, world!'
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, exactly 16 bytes.
+str="${S16}"
+want="${S16}"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, just a smidgen more than 16 bytes.
+str="${S16}x"
+want="${S16}x"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, exactly 32 bytes.
+str="${S32}"
+want="${S32}"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, just a smidgen more than 32 bytes.
+str="${S32}x"
+want="${S32}x"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, exactly 48 bytes.
+str="${S32}${S16}"
+want="${S32}${S16}"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, just a smidgen more than 48 bytes.
+str="${S32}${S16}x"
+want="${S32}${S16}x"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, exactly 64 bytes.
+str="${S32}${S32}"
+want="${S32}${S32}"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, just a smidgen more than 64 bytes.
+str="${S32}${S32}x"
+want="${S32}${S32}x"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, exactly 80 bytes.
+str="${S32}${S32}${S16}"
+want="${S32}${S32}${S16}"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, just a smidgen more than 80 bytes.
+str="${S32}${S32}${S16}x"
+want="${S32}${S32}${S16}x"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, exactly 96 bytes.
+str="${S32}${S32}${S32}"
+want="${S32}${S32}${S32}"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, just a smidgen more than 96 bytes.
+str="${S32}${S32}${S32}x"
+want="${S32}${S32}${S32}x"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, exactly 112 bytes.
+str="${S32}${S32}${S32}${S16}"
+want="${S32}${S32}${S32}${S16}"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, just a smidgen more than 112 bytes.
+str="${S32}${S32}${S32}${S16}x"
+want="${S32}${S32}${S32}${S16}x"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, exactly 128 bytes.
+str="${S32}${S32}${S32}${S32}"
+want="${S32}${S32}${S32}${S32}"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# No ANSI sequences, just a smidgen more than 128 bytes.
+str="${S32}${S32}${S32}${S32}x"
+want="${S32}${S32}${S32}${S32}x"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# Add some ANSI into the mix, less than 16 bytes.
+str=$(printf '\e[31mHello, world!\e[0m')
+want=$'Hello, world!'
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# Add some ANSI into the mix, "straddling" the 16 bytes boundary:
+str=$(printf '%s\e[31m%s' "${S08}" "${S08}")
+want="${S08}${S08}"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# Add some ANSI into the mix, "straddling" the 32 bytes boundary:
+str=$(printf '%s\e[31m%s' "${S16}" "${S16}")
+want="${S16}${S16}"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# Add some ANSI into the mix, "straddling" the 48 bytes boundary:
+str=$(printf '%s\e[31m%s' "${S32}" "${S16}")
+want="${S32}${S16}"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+# Add some ANSI into the mix, "straddling" the 64 bytes boundary:
+str=$(printf '%s%s\e[31m%s' "${S32}" "${S32}" "${S16}")
+want="${S32}${S32}${S16}"
+got=$(printf '%s' "$str" | ./ansi2html -S)
+str_eq_html "$str" "$want" "$got"
+
+########################################################
+
+# Similar, but without -S.
+
+# Add some ANSI into the mix, less than 16 bytes.
+str=$(printf '\e[31mHello, world!\e[0m')
+want=$'<span style="color:#AA0000;">Hello, world!</span>'
+got=$(printf '%s' "$str" | ./ansi2html -p vga)
+str_eq_html "$str" "$want" "$got"
+
+# Add some ANSI into the mix, "straddling" the 16 bytes boundary:
+str=$(printf '%s\e[31m%s' "${S08}" "${S08}")
+want=$(printf '%s<span style="color:#AA0000;">%s</span>' "${S08}" "${S08}")
+got=$(printf '%s' "$str" | ./ansi2html -p vga)
+str_eq_html "$str" "$want" "$got"
+
+# Add some ANSI into the mix, "straddling" the 32 bytes boundary:
+str=$(printf '%s\e[31m%s' "${S16}" "${S16}")
+want=$(printf '%s<span style="color:#AA0000;">%s</span>' "${S16}" "${S16}")
+got=$(printf '%s' "$str" | ./ansi2html -p vga)
+str_eq_html "$str" "$want" "$got"
+
+# Add some ANSI into the mix, "straddling" the 48 bytes boundary:
+str=$(printf '%s\e[31m%s' "${S32}" "${S16}")
+want=$(printf '%s<span style="color:#AA0000;">%s</span>' "${S32}" "${S16}")
+got=$(printf '%s' "$str" | ./ansi2html -p vga)
+str_eq_html "$str" "$want" "$got"
+
+# Add some ANSI into the mix, "straddling" the 64 bytes boundary:
+str=$(printf '%s%s\e[31m%s' "${S32}" "${S32}" "${S16}")
+want=$(printf '%s%s<span style="color:#AA0000;">%s</span>' "${S32}" "${S32}" "${S16}")
+got=$(printf '%s' "$str" | ./ansi2html -p vga)
+str_eq_html "$str" "$want" "$got"
+
+done_testing


### PR DESCRIPTION
- Show the "status" of whether "-S" is running AVX2, SSE2 or the "old" implementation (if opted out via WANT_DEFAULT).
- Opt into via WANT_AVX2, WANT_SSE2, WANT_DEFAULT or let the compiler pick.
- Workflows peppered with "--help" to show what the flow got. The build and tags don't have -march=native, so they shouldn't build AVX2 under x86_64. Note you'll get SSE2 on x86_64 as every x86_64 can do SSE2. But if you locally build it via "make", you'll likely have AVX2 if you add "-march=native" and you've a AVX2-capable processor.

What the "improved" versions of "-S" and ansi2html do is go through the input buffer, "as usual", but first try to see if we're "lucky" and are in the state where we're handling "text" and looking for an ESC character (only, for stripping; or also "&", "<" and ">" for ansi2html), and just so happen to have a 16- (for SSE2) or 32-bytes (for AVX2) series of bytes which are NOT in that list. If so, we can just (output the span if we need to, for ansi2html) copy the lot to the output buffer, without any need to go through the state machine byte by byte, and maintaining the "STATE_TEXT" state, too.

To speed things up a little bit further, this is only performed if we're at the "right" *boundary* to use _aligned_ AVX2/SSE2 instructions.

If an ESC (or funny character) is found, and it's at a byte greater than 0, we "shortcut" by memcpy'ing the bytes between the first and the non-text character to the output buffer (no need to get through the state machine for that!), and then proceed with the "usual" processing byte by byte from the ESC (or funny character) on.

For a "silly" case where the whole input is large and doesn't have any escape character at all (i.e. say it's a 1GiB of "just text", no ESC at all), this speeds things up fairly considerably (on my machine, for a 1.1GiB of "just text", from 1.5s to around 150ms for AVX2 and 190ms for SSE2).

In the most pernicious case where the whole input is pretty much mostly escape codes, i.e. repetitions of "\e[0;38;5;NNNmNNN" or similar, and therefore the chance to hit a streak of "all non-esc" is pretty much nil, the performance is a wee bit worse than previously, but that's not really a common enough case IMO.

For my usual 500MiB test file with a mix and match of heavy ANSI code and a bit of text, this version can be a wee bit faster: around 390ms for the AVX2 version, vs 430+ms for the older version.
