### PR TITLE
workflows: higher timeout for tests

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -44,7 +44,7 @@ jobs:
           printf '\e[0;31mred\e[0;1;31mbright red\e[0m' | ./ansi2html -b -p vga
           echo
       - name: run tests
-        timeout-minutes: 1
+        timeout-minutes: 2
         run: |
           make run-tests
   build-static:
@@ -152,7 +152,7 @@ jobs:
         run: |
           ./ansi2html --help
       - name: run tests
-        timeout-minutes: 1
+        timeout-minutes: 2
         run: |
           make run-tests
       - name: "Compress for ${{matrix.arch}} [with iTerm2 palettes]"


### PR DESCRIPTION
... as after the last merge to master it timed out on macos as 1 minute was too little.