### PR TITLE
Mf/202501 optimize strip

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -46,7 +46,7 @@ jobs:
       - name: run tests
         timeout-minutes: 2
         run: |
-          make run-tests
+          make prove
   build-static:
     runs-on: ubuntu-latest
     container: alpine:latest
@@ -154,7 +154,7 @@ jobs:
       - name: run tests
         timeout-minutes: 2
         run: |
-          make run-tests
+          make prove
       - name: "Compress for ${{matrix.arch}} [with iTerm2 palettes]"
         timeout-minutes: 1
         run: |

--- a/Makefile
+++ b/Makefile
@@ -89,3 +89,7 @@ clean:
 .PHONY: run-tests
 run-tests:
 	@prove -v tests/*.sh
+
+.PHONY: prove
+prove:
+	@prove tests/*.sh

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define MAX_SGRS 128
+
 #ifdef ITERM2_COLOR_SCHEMES
 #define WITH_ITERM2_COLOR_SCHEMES "Has"
 #else
@@ -138,7 +140,7 @@ static inline __attribute__((always_inline)) void just_strip_it(void)
     char buffer[INPUT_BUFFER_SIZE];
     buffer[0] = '\0';
     size_t sgr_chars_len = 0;
-    unsigned char sgrs[128];
+    unsigned char sgrs[MAX_SGRS];
     size_t sgrs_len = 0;
     long current_sgr_value = 0L;
     size_t read = 0;
@@ -348,7 +350,7 @@ static inline __attribute__((always_inline)) void ansi2html(
     buffer[0] = '\0';
     size_t sgr_chars_len = 0;
     size_t current_sgr_len = 0;
-    unsigned char sgrs[128];
+    unsigned char sgrs[MAX_SGRS];
     size_t sgrs_len = 0;
     long current_sgr_value = 0L;
     size_t read = 0;


### PR DESCRIPTION
just_strip_it: rearrange to speed things up

- use a few "register" variables for likely hot spots
- stop tracking the sgrs[] as we mostly don't care about previous values (i.e. was there a "1;"?) if we're stripping ANSI: all we care is really about finding the ending "m" and _verifying_ (but we could drop that) that each number in the ";" sequence is 0-255.
- rearrange the switch() into a series of if/else roughly based on how prevalent it ought to be in a common ANSI text input.

Feeding this my usual 50M-100M-1G-1.5G ANSI-laden files, both "normal" (from an ANSI telnet-based MUD) and "pernicious" where basically every character or so is a different color, this speeds things up in the region of 2-7% depending.
Files without ANSI don't get any particular speed-up.
